### PR TITLE
[muzi] moving prettier under "dependencies" from "devDependencies"

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,14 +35,14 @@
         "coveralls": "3.0.0",
         "husky": "0.14.3",
         "jest": "22.2.2",
-        "lint-staged": "6.1.0",
-        "prettier": "1.10.2"
+        "lint-staged": "6.1.0"
     },
     "dependencies": {
         "chalk": "2.3.1",
         "commander": "2.14.1",
         "lodash": "4.17.5",
-        "shelljs": "0.8.1"
+        "shelljs": "0.8.1",
+        "prettier": "1.10.2"
     },
     "lint-staged": {
         "*.js": ["node_modules/.bin/prettier --write", "git add"]


### PR DESCRIPTION
Currently, an error occurs when using 'generate-react-code' on a machine with no prettier installed. This should have been part of origin pull request.